### PR TITLE
specify java encoding

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -90,7 +90,7 @@
 
     <!-- Need classpath to run this -->
     <target name="compile" depends="init" description="compile the source ">
-        <javac includeantruntime="false" srcdir="${src.dir}" destdir="${build.dir}" classpathref="classpath" />
+        <javac includeantruntime="false" srcdir="${src.dir}" destdir="${build.dir}" classpathref="classpath" encoding="UTF-8" />
     </target>
 
     <!-- Group all dependencies into a big dependency-all.jar -->


### PR DESCRIPTION
Specify UTF-8 as the file encoding to `javac` so that the project can be built on non-English systems.
