### PR TITLE
Fix crash on missing output dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build/
+/bin/
 /dist/
 /output/
 /input/test

--- a/src/shef/mt/DocLevelFeatureExtractor.java
+++ b/src/shef/mt/DocLevelFeatureExtractor.java
@@ -103,10 +103,14 @@ public class DocLevelFeatureExtractor implements FeatureExtractor {
 
     public void run() {
         //Set output writer for feature values:
-        String outputPath = this.output + File.separator + "output.txt";
+        File outputFile = new File(this.output, "output.txt");
         BufferedWriter outWriter = null;
         try {
-            outWriter = new BufferedWriter(new FileWriter(outputPath));
+            //If the directory containing the file does not exist
+            outputFile.getParentFile().mkdirs();
+            //Create the file if it does not exist yet
+            outputFile.createNewFile();
+            outWriter = new BufferedWriter(new FileWriter(outputFile));
         } catch (IOException ex) {
             Logger.getLogger(DocLevelFeatureExtractor.class.getName()).log(Level.SEVERE, null, ex);
         }

--- a/src/shef/mt/SentenceLevelFeatureExtractor.java
+++ b/src/shef/mt/SentenceLevelFeatureExtractor.java
@@ -84,10 +84,14 @@ public class SentenceLevelFeatureExtractor implements FeatureExtractor {
 
     public void run() {
         //Set output writer for feature values:
-        String outputPath = this.output + File.separator + "output.txt";
+        File outputFile = new File(this.output, "output.txt");
         BufferedWriter outWriter = null;
         try {
-            outWriter = new BufferedWriter(new FileWriter(outputPath));
+            //If the directory containing the file does not exist
+            outputFile.getParentFile().mkdirs();
+            //Create the file if it does not exist yet
+            outputFile.createNewFile();
+            outWriter = new BufferedWriter(new FileWriter(outputFile));
         } catch (IOException ex) {
             Logger.getLogger(SentenceLevelFeatureExtractor.class.getName()).log(Level.SEVERE, null, ex);
         }

--- a/src/shef/mt/WordLevelFeatureExtractor.java
+++ b/src/shef/mt/WordLevelFeatureExtractor.java
@@ -85,10 +85,14 @@ public class WordLevelFeatureExtractor implements FeatureExtractor{
 
     public void run() {
         //Set output writer for feature values:
-        String outputPath = this.output + File.separator + "output.txt";
+        File outputFile = new File(this.output, "output.txt");
         BufferedWriter outWriter = null;
         try {
-            outWriter = new BufferedWriter(new FileWriter(outputPath));
+            //If the directory containing the file does not exist
+            outputFile.getParentFile().mkdirs();
+            //Create the file if it does not exist yet
+            outputFile.createNewFile();
+            outWriter = new BufferedWriter(new FileWriter(outputFile));
         } catch (IOException ex) {
             Logger.getLogger(WordLevelFeatureExtractor.class.getName()).log(Level.SEVERE, null, ex);
         }


### PR DESCRIPTION
When freshly cloning the project, the `output/test/output.txt` file is not present, nor the parent folders. When running the basic usage command the program crashes as the folders are not created (however creates them in the process). After crashing several times, `output/test/output.txt` is finally created and the program works.

```
java -cp QuEst++.jar:lib/* shef.mt.WordLevelFeatureExtractor -lang english spanish -input input/source.word-level.en input/target.word-level.es -alignments lang_resources/alignments/alignments.word-level.out -config config/config.word-level.properties
```

This is not an issue for already existing installations, as they already contain the output file dir structure, but for better out-of-the-box experience this should be fixed. This pull request adds code that properly handles output file initialization.

This bug appears on Linux (Fedora 30) with Java 1.8.0. Not tested on Windows nor OS/X. Tested on WordLevel, but it's identical on SentenceLevel and DocumentLevel.


Since this commit changes the Java source files, the executable should be updated as well. The last update to `QuEst++.jar` was 4 years ago, when GitHub didn't have the max 100 MB files policy. I tried adding `QuEst++.jar` to LFS (standard procedure), but alas I'm [not allowed](https://github.com/git-lfs/git-lfs/issues/1906) to add new LFS files to public forks. If this pull request is accepted, please follow up with a commit, which updates `QuEst++.jar` so that it matches the source files.